### PR TITLE
Use the author's email address and not the committer's.

### DIFF
--- a/java/com/google/devtools/moe/client/dvcs/git/GitRevisionHistory.java
+++ b/java/com/google/devtools/moe/client/dvcs/git/GitRevisionHistory.java
@@ -89,7 +89,7 @@ public class GitRevisionHistory extends AbstractRevisionHistory {
     }
 
     // Format: hash, author, fullAuthor, date, parents, full commit message (subject and body)
-    String format = Joiner.on(LOG_DELIMITER).join("%H", "%an", "%aN <%cE>", "%ad", "%P", "%B");
+    String format = Joiner.on(LOG_DELIMITER).join("%H", "%an", "%aN <%aE>", "%ad", "%P", "%B");
 
     String log;
     try {


### PR DESCRIPTION
We've constantly had to fixup open source contributions to properly
attribute the change to them because of this.  I see no good reason
to keep the current behavior.
